### PR TITLE
Remove span from header links so active link color works again

### DIFF
--- a/app/components/Header.vue
+++ b/app/components/Header.vue
@@ -18,8 +18,7 @@ nl:
     nav(:class='{hide: !mobileMenuOpen}')
       ul
         li(v-for='(item, i) in menu' :key='i')
-          NuxtLink(:to='localePath(item.pathName)')
-            span {{$t(item.pathTitle)}}
+          NuxtLink(:to='localePath(item.pathName)') {{$t(item.pathTitle)}}
     Burger.burger(name='menu' :menuOpen='mobileMenuOpen' @click.native='mobileMenuOpen = !mobileMenuOpen')
     .slot(v-if='hasSlot')
       slot
@@ -130,7 +129,7 @@ export default {
           margin-right: var(--ui-margin-x)
           &:last-of-type
             margin-right: 0
-          a, span
+          a
             color: var(--color-dark)
             font-weight: var(--font-weight-bold)
             text-decoration: none


### PR DESCRIPTION
Span was not inheriting color from nuxt link, removing the span fixed the issue.